### PR TITLE
Fix dependency for Humble

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <depend>geometry_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>python3-serial</depend>
+  <depend>python-transforms3d-pip</depend>
   <depend>tf_transformations</depend>
 
   <export>

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,7 @@
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>diagnostic_msgs</depend>
-  <depend>python-serial</depend>
+  <depend>python3-serial</depend>
   <depend>tf_transformations</depend>
 
   <export>


### PR DESCRIPTION
Modified package.xml for `rosdep install` on Humble.
- `python-serial` is for Python2 and cannot be installed on Ubuntu 22.04
- `transforms3d` was not listed though it is a dependency