### PR TITLE
Fix crash for legacy MTi devices

### DIFF
--- a/xsens_driver/mtdevice.py
+++ b/xsens_driver/mtdevice.py
@@ -1153,7 +1153,7 @@ class MTDevice(object):
             # TODO at that point data should be empty
         except struct.error as e:
             raise MTException("could not parse MTData message.")
-        if data != '':
+        if len(data) != 0 :
             raise MTException("could not parse MTData message (too long).")
         return output
 

--- a/xsens_driver/mtnode.py
+++ b/xsens_driver/mtnode.py
@@ -381,7 +381,7 @@ class XSensDriver(rclpy.node.Node):
 
         def fill_from_Sample(ts):
             """Catch 'Sample' MTData blocks."""
-            self.h.seq = ts
+            # self.h.seq = ts
 
         # MTData2
         def fill_from_Temperature(o):


### PR DESCRIPTION
Fix for #4 

After some debugging, turns out the messages aren't actually too long.
The `parse_MTData` method in `mtdevice.py` used for legacy devices perform a test to make sure that all data has been parsed. The comparison (`!=`) was done between a byte array and an empty string, which always evaluated to true because of the different types. I suspect this might be from the move from python2 to python3. Using `len() != 0 ` is a more robust solution.
An other solution would have been to use an empty byte array `b''` for the test.

After this fix a second error pops up :
In the method `fill_from_Sample` of `mtnode.py`, there was an attempt to fill the `seq` field of the `Header` message. This field has been removed with ROS2 : http://design.ros2.org/articles/changes.html . As it doesn't seems to be used anywhere else in the project, I just commented the line trying to acces the field. It might be better to remove the function entirely, but I would probably need to alter `parse_MTData` to do so.

I can now get data from my IMU (MTi-28A53G35).
I don't think this fix has side-effects, but I don't have newer devices to test it on.