### PR TITLE
Enable diagnostics via param

### DIFF
--- a/launch/xsens_driver.launch.xml
+++ b/launch/xsens_driver.launch.xml
@@ -1,7 +1,7 @@
 <launch>
     <!-- parameters -->
     <arg name="device" default="auto"/>
-    <arg name="enable_diagnostics" default="False"/>
+    <arg name="enable_diagnostics" default="True"/>
     <arg name="baudrate" default="0"/>
     <arg name="timeout" default="0.002"/>
     <arg name="initial_wait" default="0.1"/>

--- a/launch/xsens_driver.launch.xml
+++ b/launch/xsens_driver.launch.xml
@@ -1,6 +1,7 @@
 <launch>
     <!-- parameters -->
     <arg name="device" default="auto"/>
+    <arg name="enable_diagnostics" default="False"/>
     <arg name="baudrate" default="0"/>
     <arg name="timeout" default="0.002"/>
     <arg name="initial_wait" default="0.1"/>
@@ -14,6 +15,7 @@
     <!-- node -->
     <node pkg="xsens_driver" exec="mtnode.py" name="xsens_driver" output="screen" >
         <param name="device" value="$(var device)"/>
+        <param name="enable_diagnostics" value="$(var enable_diagnostics)" type="bool"/>
         <param name="baudrate" value="$(var baudrate)"/>
         <param name="timeout" value="$(var timeout)"/>
         <param name="initial_wait" value="$(var initial_wait)"/>

--- a/xsens_driver/mtnode.py
+++ b/xsens_driver/mtnode.py
@@ -28,7 +28,7 @@ class XSensDriver(rclpy.node.Node):
         baudrate = self.get_param('baudrate', 0)
         timeout = self.get_param('timeout', 0.002)
         initial_wait = self.get_param('initial_wait', 0.1)
-        self.enable_diagnostics = self.get_param('enable_diagnostics', False)
+        self.enable_diagnostics = self.get_param('enable_diagnostics', True)
         if device == 'auto':
             devs = mtdevice.find_devices(timeout=timeout, initial_wait=initial_wait)
             if devs:

--- a/xsens_driver/mtnode.py
+++ b/xsens_driver/mtnode.py
@@ -28,6 +28,7 @@ class XSensDriver(rclpy.node.Node):
         baudrate = self.get_param('baudrate', 0)
         timeout = self.get_param('timeout', 0.002)
         initial_wait = self.get_param('initial_wait', 0.1)
+        self.enable_diagnostics = self.get_param('enable_diagnostics', False)
         if device == 'auto':
             devs = mtdevice.find_devices(timeout=timeout, initial_wait=initial_wait)
             if devs:
@@ -744,7 +745,7 @@ class XSensDriver(rclpy.node.Node):
             if self.ecef_pub is None:
                 self.ecef_pub = self.create_publisher(PointStamped, 'ecef', 10)
             self.ecef_pub.publish(self.ecef_msg)
-        if self.pub_diag:
+        if self.pub_diag and self.enable_diagnostics:
             self.diag_msg.header = self.h
             if self.diag_pub is None:
                 self.diag_pub = self.create_publisher(DiagnosticArray, '/diagnostics', 10)


### PR DESCRIPTION
Hi there,

in some cases we don't want the node to publish diagnostic msgs. This PR adds a launch argument to turn diagnostics on/off. What do you think?